### PR TITLE
Fix function 2 in EmpQueries

### DIFF
--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -45,17 +45,15 @@ currDate = Date 2025 3 26
 
 -- Check if two employes work the same years
 (===) :: Employee -> Employee -> Bool
-(===) emp1 emp2 = (year currDate - year (joinedOn emp1)) == (year currDate - year (joinedOn emp2))
+(===) emp1 emp2 = yearDiff (joinedOn emp1) currDate == yearDiff (joinedOn emp2) currDate
 
 groupByTenure :: [Employee] -> [[Employee]]
 groupByTenure emps = groupBy (===) (sortOn tenureYears emps)
-      where tenureYears emp = year currDate - year (joinedOn emp) -- Sort for better grouping
+      where tenureYears emp = yearDiff (joinedOn emp) currDate -- Sort for better grouping
 
 assignTenure :: [Employee] -> (Int, [Employee])
-assignTenure emps  = 
-      let getYear  = year (joinedOn (head emps))
-          yearDiff = (year currDate) - getYear
-      in  (yearDiff, emps)
+assignTenure emps  = (getYear, emps)
+    where getYear = yearDiff (joinedOn (head emps)) currDate
 
 calculateTenure :: Employee -> Int
 calculateTenure emp =
@@ -68,7 +66,6 @@ yearDiff :: Date -> Date -> Int
 yearDiff date1 date2 = year date2 - year date1
 
 
-
 -- 1.
 employeesWithOverlappingPermits :: [Employee] -> [(EId, EId)]
 employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
@@ -79,7 +76,7 @@ employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
   Just permit2 <- [permit emp2],
   joinedOn emp1 <= expiryDate permit2 && expiryDate permit1 >= joinedOn emp2
   ]
-  
+
 
 -- 2.
 employeesByTenure :: [Employee] -> [(Int, [Employee])]
@@ -183,7 +180,6 @@ prettyEmployeeGroup groups = do
       putStrLn $ "\n---- Group " ++ show n ++ " (" ++ show (length emps) ++ " employees) ----"
       mapM_ (putStr . prettyEmployee) emps
 
--- Modified version of your existing prettyEmployee
 prettyEmployee :: Employee -> String
 prettyEmployee emp = unlines
   [ "  Employee ID: " ++ empId emp

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -18,8 +18,8 @@ data Employee = Emp
 data Date = Date 
   { 
     year  :: Int,
-    month :: Int, --month should not exceed 12
-    day   :: Int  --no invalid days
+    month :: Int,
+    day   :: Int
   }
   deriving (Show, Eq, Ord)
 
@@ -37,11 +37,6 @@ mkDate year month day =
                          | otherwise      = day > 0 && day <= 30
       in
             if isYearValid && isMonthValid && isDayValid then Just (Date year month day) else Nothing
-
-
--- Main
-main :: IO ()
-main = prettyTenureGroups (employeesByTenure testEmployees)
 
 
 -- Helper
@@ -74,7 +69,7 @@ yearDiff date1 date2 = year date2 - year date1
 
 
 
--- 1
+-- 1.
 employeesWithOverlappingPermits :: [Employee] -> [(EId, EId)]
 employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
   emp1 <- emps,
@@ -86,7 +81,7 @@ employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
   ]
 
 
--- 2
+-- 2.
 employeesByTenure :: [Employee] -> [(Int, [Employee])]
 employeesByTenure emps = map assignTenure (groupByTenure emps)
 
@@ -97,12 +92,12 @@ longestWorkingEmployee []   = Nothing
 longestWorkingEmployee emps = Just (maximumBy (\emp1 emp2 -> compare (calculateTenure emp1) (calculateTenure emp2)) emps)
 
 
---4. confident
+--4.
 withExpiredPermit :: [Employee] -> Date -> [EId]
 withExpiredPermit emps currDate = [empId emp | emp <- emps, Just p <- [permit emp], currDate > expiryDate p]
 
 
---5. confident
+--5.
 avgYearsWorked :: [Employee] -> Double
 avgYearsWorked [] = 0
 avgYearsWorked emps = if totalEmployees == 0
@@ -114,6 +109,14 @@ avgYearsWorked emps = if totalEmployees == 0
    tenures emps  = fromIntegral $ sum [calculateTenure emp | emp <- emps]
 
 
+
+--------------------------------------------------------------------
+-- Testing purposes
+--------------------------------------------------------------------
+
+-- Main
+main :: IO ()
+main = prettyTenureGroups (employeesByTenure testEmployees)
 
 
 -- Test

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -1,197 +1,255 @@
-import Data.List (sortOn, groupBy, maximumBy)
+import Data.List (groupBy, maximumBy, sortOn)
 import Text.Printf (printf)
 
 type EId = String
 
-data WorkPermit = Permit { number :: String, expiryDate :: Date }
-   deriving (Show, Eq)
+data WorkPermit = Permit
+  { number :: String
+  , expiryDate :: Date
+  } deriving (Show, Eq)
 
 data Employee = Emp
-   {
-    empId    :: EId,
-    joinedOn :: Date,
-    permit   :: Maybe WorkPermit,
-    leftOn   :: Maybe Date
-   }
-   deriving (Show, Eq)
+  { empId :: EId
+  , joinedOn :: Date
+  , permit :: Maybe WorkPermit
+  , leftOn :: Maybe Date
+  } deriving (Show, Eq)
 
-data Date = Date 
-  { 
-    year  :: Int,
-    month :: Int,
-    day   :: Int
-  }
-  deriving (Show, Eq, Ord)
-
+data Date = Date
+  { year :: Int
+  , month :: Int
+  , day :: Int
+  } deriving (Show, Eq, Ord)
 
 -- Smart Constructors   
 mkDate :: Int -> Int -> Int -> Maybe Date
-mkDate year month day = 
-      let
-            isYearValid    = year > 0
-            isMonthValid   = month > 0 && month < 13
-            isLeapYear     = (year `mod` 400 == 0) || (year `mod` 100 /= 0 && year `mod` 4 == 0)
-            isKnuckleMonth = month `elem` [1, 3, 5, 7, 8, 10, 12]
-            isDayValid   | month == 2     = day > 0 && if isLeapYear then day <= 29 else day <= 28
-                         | isKnuckleMonth = day > 0 && day <= 31
-                         | otherwise      = day > 0 && day <= 30
-      in
-            if isYearValid && isMonthValid && isDayValid then Just (Date year month day) else Nothing
-
+mkDate year month day =
+  let isYearValid = year > 0
+      isMonthValid = month > 0 && month < 13
+      isLeapYear =
+        (year `mod` 400 == 0) || (year `mod` 100 /= 0 && year `mod` 4 == 0)
+      isKnuckleMonth = month `elem` [1, 3, 5, 7, 8, 10, 12]
+      isDayValid
+        | month == 2 =
+          day > 0
+            && if isLeapYear
+                 then day <= 29
+                 else day <= 28
+        | isKnuckleMonth = day > 0 && day <= 31
+        | otherwise = day > 0 && day <= 30
+   in if isYearValid && isMonthValid && isDayValid
+        then Just (Date year month day)
+        else Nothing
 
 -- Helper
 currDate :: Date
-currDate = Date 2025 3 26 
+currDate = Date 2025 3 26
 
 -- Check if two employes work the same years
 (===) :: Employee -> Employee -> Bool
-(===) emp1 emp2 = yearDiff (joinedOn emp1) currDate == yearDiff (joinedOn emp2) currDate
+(===) emp1 emp2 =
+  yearDiff (joinedOn emp1) currDate == yearDiff (joinedOn emp2) currDate
 
 groupByTenure :: [Employee] -> [[Employee]]
 groupByTenure emps = groupBy (===) (sortOn tenureYears emps)
-      where tenureYears emp = yearDiff (joinedOn emp) currDate -- Sort for better grouping
+  where
+    tenureYears emp = yearDiff (joinedOn emp) currDate -- Sort for better grouping
 
 assignTenure :: [Employee] -> (Int, [Employee])
-assignTenure emps  = (getYear, emps)
-    where getYear = yearDiff (joinedOn (head emps)) currDate
+assignTenure emps = (getYear, emps)
+  where
+    getYear = yearDiff (joinedOn (head emps)) currDate
 
 calculateTenure :: Employee -> Int
 calculateTenure emp =
-  let endDate = case leftOn emp of
-                    Just date -> date
-                    Nothing   -> currDate
-  in yearDiff (joinedOn emp) endDate
+  let endDate =
+        case leftOn emp of
+          Just date -> date
+          Nothing -> currDate
+   in yearDiff (joinedOn emp) endDate
 
 yearDiff :: Date -> Date -> Int
 yearDiff date1 date2 = year date2 - year date1
 
-
 -- 1.
 employeesWithOverlappingPermits :: [Employee] -> [(EId, EId)]
-employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
-  emp1 <- emps,
-  emp2 <- emps,
-  empId emp1 < empId emp2,
-  Just permit1 <- [permit emp1], 
-  Just permit2 <- [permit emp2],
-  joinedOn emp1 <= expiryDate permit2 && expiryDate permit1 >= joinedOn emp2
+employeesWithOverlappingPermits emps =
+  [ (empId emp1, empId emp2)
+  | emp1 <- emps
+  , emp2 <- emps
+  , empId emp1 < empId emp2
+  , Just permit1 <- [permit emp1]
+  , Just permit2 <- [permit emp2]
+  , joinedOn emp1 <= expiryDate permit2 && expiryDate permit1 >= joinedOn emp2
   ]
-
 
 -- 2.
 employeesByTenure :: [Employee] -> [(Int, [Employee])]
 employeesByTenure emps = map assignTenure (groupByTenure emps)
 
-
 --3.
 longestWorkingEmployee :: [Employee] -> Maybe Employee
-longestWorkingEmployee []   = Nothing
-longestWorkingEmployee emps = Just (maximumBy (\emp1 emp2 -> compare (calculateTenure emp1) (calculateTenure emp2)) emps)
-
+longestWorkingEmployee [] = Nothing
+longestWorkingEmployee emps =
+  Just
+    (maximumBy
+       (\emp1 emp2 -> compare (calculateTenure emp1) (calculateTenure emp2))
+       emps)
 
 --4.
 withExpiredPermit :: [Employee] -> Date -> [EId]
-withExpiredPermit emps currDate = [empId emp | emp <- emps, Just p <- [permit emp], currDate > expiryDate p]
-
+withExpiredPermit emps currDate =
+  [empId emp | emp <- emps, Just p <- [permit emp], currDate > expiryDate p]
 
 --5.
 avgYearsWorked :: [Employee] -> Double
 avgYearsWorked [] = 0
-avgYearsWorked emps = if totalEmployees == 0
-                      then 0
-                      else tenures emps / totalEmployees
+avgYearsWorked emps =
+  if totalEmployees == 0
+    then 0
+    else tenures emps / totalEmployees
   where
-   totalEmployees = fromIntegral $ length emps
-   tenures []    = 0
-   tenures emps  = fromIntegral $ sum [calculateTenure emp | emp <- emps]
+    totalEmployees = fromIntegral $ length emps
+    tenures [] = 0
+    tenures emps = fromIntegral $ sum [calculateTenure emp | emp <- emps]
 
+-- ===================== TEST DATA =====================
+-- Test Dates
+date2020 :: Date
+date2020 = Date 2020 1 1
 
+date2021 :: Date
+date2021 = Date 2021 1 1
 
---------------------------------------------------------------------
--- Testing purposes
---------------------------------------------------------------------
+date2022 :: Date
+date2022 = Date 2022 1 1
 
--- Main
+date2023 :: Date
+date2023 = Date 2023 1 1
+
+date2024 :: Date
+date2024 = Date 2024 1 1
+
+date2026 :: Date
+date2026 = Date 2026 1 1
+
+date2027 :: Date
+date2027 = Date 2027 1 1
+
+-- Test Permits
+permit2024 :: WorkPermit
+permit2024 = Permit "P1" date2024
+
+permit2026 :: WorkPermit
+permit2026 = Permit "P2" date2026
+
+permit2027 :: WorkPermit
+permit2027 = Permit "P3" date2027
+
+-- Test Employees
+emp1 :: Employee
+emp1 = Emp "E1" date2020 (Just permit2024) Nothing
+
+emp2 :: Employee
+emp2 = Emp "E2" date2021 (Just permit2026) Nothing
+
+emp3 :: Employee
+emp3 = Emp "E3" date2022 (Just permit2027) Nothing
+
+emp4 :: Employee
+emp4 = Emp "E4" date2020 Nothing (Just date2023)
+
+emp5 :: Employee
+emp5 = Emp "E5" date2021 Nothing Nothing
+
+-- Sample employee lists for testing
+testEmps1 :: [Employee]
+testEmps1 = [emp1, emp2, emp3]
+
+testEmps2 :: [Employee]
+testEmps2 = [emp1, emp2, emp3, emp4, emp5]
+
+-- ===================== TEST FUNCTIONS =====================
+-- Test for employeesWithOverlappingPermits
+testOverlappingPermits :: Bool
+testOverlappingPermits =
+  let result1 = employeesWithOverlappingPermits testEmps1
+      result2 = employeesWithOverlappingPermits [emp1, emp2]
+      expected1 = [("E1", "E2"), ("E1", "E3"), ("E2", "E3")]
+      expected2 = [("E1", "E2")]
+   in result1 == expected1 && result2 == expected2
+
+-- Test for employeesByTenure
+testEmployeesByTenure :: Bool
+testEmployeesByTenure =
+  let result = employeesByTenure testEmps1
+        -- Check structure and content rather than exact order
+      hasCorrectTenures =
+        all (\tenure -> tenure `elem` [3, 4, 5]) (map fst result)
+      hasAllEmployees = sum (map (length . snd) result) == length testEmps1
+        -- Check that employees are correctly grouped by tenure
+      correctGrouping =
+        all
+          (\(tenure, emps) ->
+             all (\emp -> yearDiff (joinedOn emp) currDate == tenure) emps)
+          result
+   in hasCorrectTenures && hasAllEmployees && correctGrouping
+
+-- Test for longestWorkingEmployee
+testLongestWorkingEmployee :: Bool
+testLongestWorkingEmployee =
+  let result1 = longestWorkingEmployee testEmps1
+      result2 = longestWorkingEmployee testEmps2
+      result3 = longestWorkingEmployee []
+   in result1 == Just emp1 && result2 == Just emp1 && result3 == Nothing
+
+-- Test for withExpiredPermit
+testWithExpiredPermit :: Bool
+testWithExpiredPermit =
+  let testDate = Date 2025 1 2
+      result = withExpiredPermit testEmps1 testDate
+   in result == ["E1"] -- Only emp1's permit expired (2024)
+
+-- Test for avgYearsWorked
+testAvgYearsWorked :: Bool
+testAvgYearsWorked =
+  let result1 = avgYearsWorked testEmps1
+      result2 = avgYearsWorked testEmps2
+      result3 = avgYearsWorked []
+        -- testEmps1: All still employed in 2025, joined in 2020, 2021, 2022 -> tenures 5, 4, 3 -> avg 4.0
+        -- testEmps2: Same plus emp4 (2020-2023: 3 years) and emp5 (2021-2025: 4 years) -> avg 3.8
+   in result1 == 4.0 && result2 == 3.8 && result3 == 0.0
+
+-- Run all tests
+runAllTests :: [(String, Bool)]
+runAllTests =
+  [ ("employeesWithOverlappingPermits", testOverlappingPermits)
+  , ("employeesByTenure", testEmployeesByTenure)
+  , ("longestWorkingEmployee", testLongestWorkingEmployee)
+  , ("withExpiredPermit", testWithExpiredPermit)
+  , ("avgYearsWorked", testAvgYearsWorked)
+  ]
+
+-- Main test function
+testEmployeeQueries :: IO ()
+testEmployeeQueries = do
+  putStrLn "Running employee query tests..."
+  let results = runAllTests
+  mapM_
+    (\(name, result) ->
+       putStrLn
+         $ name
+             ++ ": "
+             ++ if result
+                  then "PASS"
+                  else "FAIL")
+    results
+  putStrLn
+    $ "Tests passed: "
+        ++ show (length (filter snd results))
+        ++ "/"
+        ++ show (length results)
+
+-- For easy testing
 main :: IO ()
-main = prettyTenureGroups (employeesByTenure testEmployees)
-
-
--- Test
-testEmployees :: [Employee]
-testEmployees = 
-  [ Emp "E001" (Date 2020 3 15)
-      (Just (Permit "P100" (Date 2023 3 15))) 
-      Nothing
-  , Emp "E002" (Date 2021 6 10) 
-      (Just (Permit "P200" (Date 2024 6 10))) 
-      (Just (Date 2023 12 31))
-  , Emp "E003" (Date 2022 1 5) 
-      Nothing 
-      Nothing
-  , Emp "E004" (Date 2022 9 22) 
-      (Just (Permit "P400" (Date 2025 9 22))) 
-      Nothing
-  , Emp "E005" (Date 2023 4 1) 
-      (Just (Permit "P500" (Date 2026 4 1))) 
-      (Just (Date 2024 4 1))]
-
-testEmployees2 :: [Employee]
-testEmployees2 = 
-  [ Emp "E001" (fromJust $ mkDate 2020 3 15) 
-      (Just $ Permit "P100" (fromJust $ mkDate 2023 3 15)) 
-      Nothing
-  , Emp "E002" (fromJust $ mkDate 2021 6 10)
-      (Just $ Permit "P200" (fromJust $ mkDate 2024 6 10))
-      (Just $ fromJust $ mkDate 2023 12 31)
-  , Emp "E003" (fromJust $ mkDate 2022 1 5)
-      Nothing
-      Nothing
-  , Emp "E004" (fromJust $ mkDate 2022 9 22)
-      (Just $ Permit "P400" (fromJust $ mkDate 2025 9 22))
-      Nothing
-  , Emp "E005" (fromJust $ mkDate 2023 4 1)
-      (Just $ Permit "P500" (fromJust $ mkDate 2026 4 1))
-      (Just $ fromJust $ mkDate 2024 4 1)
-  ]
-  where
-    fromJust (Just x) = x
-    fromJust Nothing  = error "Invalid date in test data"
-
-
--- Print
-prettyTenureGroups :: [(Int, [Employee])] -> IO ()
-prettyTenureGroups groups = do
-  putStrLn "==== Employees by Tenure ===="
-  mapM_ printGroup groups
-  where
-    printGroup (years, emps) = do
-      putStrLn $ printf "\n---- %d Year%s Tenure (%d employees) ----" 
-        years 
-        (if years /= 1 then "s" else "") 
-        (length emps)
-      mapM_ (putStr . prettyEmployee) emps
-
-prettyEmployeeGroup :: [[Employee]] -> IO ()
-prettyEmployeeGroup groups = do
-  putStrLn "==== Employee Groups ===="
-  mapM_ printGroup (zip [1..] groups)
-  where
-    printGroup (n, emps) = do
-      putStrLn $ "\n---- Group " ++ show n ++ " (" ++ show (length emps) ++ " employees) ----"
-      mapM_ (putStr . prettyEmployee) emps
-
-prettyEmployee :: Employee -> String
-prettyEmployee emp = unlines
-  [ "  Employee ID: " ++ empId emp
-  , "  Joined On:   " ++ prettyDate (joinedOn emp)
-  , "  Permit:      " ++ case permit emp of
-                          Nothing -> "None"
-                          Just p  -> number p ++ " (expires " ++ prettyDate (expiryDate p) ++ ")"
-  , "  Status:      " ++ case leftOn emp of
-                          Nothing -> "Active"
-                          Just d  -> "Left on " ++ prettyDate d
-  , ""
-  ]
-
-prettyDate :: Date -> String
-prettyDate (Date y m d) = printf "%04d-%02d-%02d" y m d
+main = testEmployeeQueries

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -28,7 +28,7 @@ data Date = Date
 mkDate :: Int -> Int -> Int -> Maybe Date
 mkDate year month day = 
       let
-            isYearValid    = year > 0 && year <= 2025
+            isYearValid    = year > 0
             isMonthValid   = month > 0 && month < 13
             isLeapYear     = (year `mod` 400 == 0) || (year `mod` 100 /= 0 && year `mod` 4 == 0)
             isKnuckleMonth = month `elem` [1, 3, 5, 7, 8, 10, 12]
@@ -121,7 +121,44 @@ main = prettyTenureGroups (employeesByTenure testEmployees)
 
 -- Test
 testEmployees :: [Employee]
-testEmployees = [Emp "E001" (Date 2020 3 15) (Just (Permit "P100" (Date 2023 3 15))) Nothing, Emp "E002" (Date 2021 6 10) (Just (Permit "P200" (Date 2024 6 10))) (Just (Date 2023 12 31)), Emp "E003" (Date 2022 1 5) Nothing Nothing, Emp "E004" (Date 2022 9 22) (Just (Permit "P400" (Date 2019 9 22))) Nothing, Emp "E005" (Date 2023 4 1) (Just (Permit "P500" (Date 2021 4 1))) (Just (Date 2024 4 1))]
+testEmployees = 
+  [ Emp "E001" (Date 2020 3 15)
+      (Just (Permit "P100" (Date 2023 3 15))) 
+      Nothing
+  , Emp "E002" (Date 2021 6 10) 
+      (Just (Permit "P200" (Date 2024 6 10))) 
+      (Just (Date 2023 12 31))
+  , Emp "E003" (Date 2022 1 5) 
+      Nothing 
+      Nothing
+  , Emp "E004" (Date 2022 9 22) 
+      (Just (Permit "P400" (Date 2025 9 22))) 
+      Nothing
+  , Emp "E005" (Date 2023 4 1) 
+      (Just (Permit "P500" (Date 2026 4 1))) 
+      (Just (Date 2024 4 1))]
+
+testEmployees2 :: [Employee]
+testEmployees2 = 
+  [ Emp "E001" (fromJust $ mkDate 2020 3 15) 
+      (Just $ Permit "P100" (fromJust $ mkDate 2023 3 15)) 
+      Nothing
+  , Emp "E002" (fromJust $ mkDate 2021 6 10)
+      (Just $ Permit "P200" (fromJust $ mkDate 2024 6 10))
+      (Just $ fromJust $ mkDate 2023 12 31)
+  , Emp "E003" (fromJust $ mkDate 2022 1 5)
+      Nothing
+      Nothing
+  , Emp "E004" (fromJust $ mkDate 2022 9 22)
+      (Just $ Permit "P400" (fromJust $ mkDate 2025 9 22))
+      Nothing
+  , Emp "E005" (fromJust $ mkDate 2023 4 1)
+      (Just $ Permit "P500" (fromJust $ mkDate 2026 4 1))
+      (Just $ fromJust $ mkDate 2024 4 1)
+  ]
+  where
+    fromJust (Just x) = x
+    fromJust Nothing  = error "Invalid date in test data"
 
 
 -- Print

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -23,24 +23,19 @@ data Date = Date
   deriving (Show, Eq, Ord)
 
 
--- Smart Constructors
+-- Smart Constructors   
 mkDate :: Int -> Int -> Int -> Maybe Date
 mkDate year month day = 
       let
-            isYearValid               = year > 0 && year <= 2025
-            isMonthValid              = month > 0 && month < 13
-            isLeapYear                = year `mod` 4 == 0
-            isFebuary                 = month == 2
-            isMonthWithThirtyOneDays  = month `elem` ([x | x <- [1..7], x `mod` 2 /= 0] ++ [y | y <- [8..12], y `mod` 2 == 0])
-            isThirtyOneDaysMonthValid = day > 0 && day <= 31
-            isThirtyDaysMonthValid    = day > 0 && day <= 30
-            isDayValid                = case isMonthWithThirtyOneDays of
-                  True -> isThirtyOneDaysMonthValid -- Check for months which have 31 days
-                  _    -> case isLeapYear of        -- Check for months which have less than 31 days
-                        True -> if isFebuary then day > 0 && day <= 29 else isThirtyDaysMonthValid -- Leap Year Febuary
-                        _    -> if isFebuary then day > 0 && day <= 28 else isThirtyDaysMonthValid -- Non-Leap Year Febuary
+            isYearValid    = year > 0 && year <= 2025
+            isMonthValid   = month > 0 && month < 13
+            isLeapYear     = (year `mod` 400 == 0) || (year `mod` 100 /= 0 && year `mod` 4 == 0)
+            isKnuckleMonth = month `elem` [1, 3, 5, 7, 8, 10, 12]
+            isDayValid   | month == 2     = day > 0 && if isLeapYear then day <= 29 else day <= 28
+                         | isKnuckleMonth = day > 0 && day <= 31
+                         | otherwise      = day > 0 && day <= 30
       in
-            if (isDayValid && isMonthValid && isDayValid) then Just (Date year month day) else Nothing
+            if isYearValid && isMonthValid && isDayValid then Just (Date year month day) else Nothing
 
 
 --1.

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -79,7 +79,7 @@ employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |
   Just permit2 <- [permit emp2],
   joinedOn emp1 <= expiryDate permit2 && expiryDate permit1 >= joinedOn emp2
   ]
-
+  
 
 -- 2.
 employeesByTenure :: [Employee] -> [(Int, [Employee])]

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -62,6 +62,16 @@ assignTenure emps  =
           yearDiff = (year currDate) - getYear
       in  (yearDiff, emps)
 
+calculateTenure :: Employee -> Int
+calculateTenure emp =
+  let endDate = case leftOn emp of
+                    Just date -> date
+                    Nothing   -> currDate
+  in yearDiff (joinedOn emp) endDate
+
+yearDiff :: Date -> Date -> Int
+yearDiff date1 date2 = year date2 - year date1
+
 
 
 -- 1
@@ -88,13 +98,8 @@ longestWorkingEmployee emps = Just (maximumBy (\emp1 emp2 -> compare (calculateT
 
 
 --4. confident
-withExpiredPermit :: [Employee] -> Maybe Date -> [EId]
-withExpiredPermit emps currDate = 
-      [empId emp | 
-      emp <- emps, 
-      Just p <- [permit emp], 
-      Just expiry <- [expiryDate p], 
-      Just curr <- [currDate], curr > expiry]
+withExpiredPermit :: [Employee] -> Date -> [EId]
+withExpiredPermit emps currDate = [empId emp | emp <- emps, Just p <- [permit emp], currDate > expiryDate p]
 
 
 --5. confident

--- a/EmployeeQueries.hs
+++ b/EmployeeQueries.hs
@@ -23,6 +23,26 @@ data Date = Date
   deriving (Show, Eq, Ord)
 
 
+-- Smart Constructors
+mkDate :: Int -> Int -> Int -> Maybe Date
+mkDate year month day = 
+      let
+            isYearValid               = year > 0 && year <= 2025
+            isMonthValid              = month > 0 && month < 13
+            isLeapYear                = year `mod` 4 == 0
+            isFebuary                 = month == 2
+            isMonthWithThirtyOneDays  = month `elem` ([x | x <- [1..7], x `mod` 2 /= 0] ++ [y | y <- [8..12], y `mod` 2 == 0])
+            isThirtyOneDaysMonthValid = day > 0 && day <= 31
+            isThirtyDaysMonthValid    = day > 0 && day <= 30
+            isDayValid                = case isMonthWithThirtyOneDays of
+                  True -> isThirtyOneDaysMonthValid -- Check for months which have 31 days
+                  _    -> case isLeapYear of        -- Check for months which have less than 31 days
+                        True -> if isFebuary then day > 0 && day <= 29 else isThirtyDaysMonthValid -- Leap Year Febuary
+                        _    -> if isFebuary then day > 0 && day <= 28 else isThirtyDaysMonthValid -- Non-Leap Year Febuary
+      in
+            if (isDayValid && isMonthValid && isDayValid) then Just (Date year month day) else Nothing
+
+
 --1.
 employeesWithOverlappingPermits :: [Employee] -> [(EId, EId)]
 employeesWithOverlappingPermits emps = [(empId emp1, empId emp2) |


### PR DESCRIPTION
- Make `mkDate` constructor for Date validation
- Create a `(===) `operator to use in a group function
- Modify groupByTenure to use groupBy using the `(===)` operator to group the sorted employees by tenure. The sorting is done for better grouping
- Modify `assignTenure` to make a tuple for an individual group of employees in the format `(Int, [Employee])`
- Modify `employeesByTenure` to apply `assignTenure` for each of the grouped employees
- Create new test employees for both `Date` and `mkDate` dates
- Create `main`, `prettyTenureGroups`, `prettyEmployeeGroup`, `prettyEmployee` and `prettyDate` for a better format in the test results